### PR TITLE
call onRowAddCancelled when closed by the add button in the header

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -230,6 +230,9 @@ export default class MaterialTable extends React.Component {
           disabled: !!this.dataManager.lastEditingRow,
           onClick: () => {
             this.dataManager.changeRowEditing();
+            if (this.state.showAddRow && calculatedProps.editable.onRowAddCancelled) {
+              calculatedProps.editable.onRowAddCancelled();
+            }
             this.setState({
               ...this.dataManager.getRenderState(),
               showAddRow: !this.state.showAddRow,


### PR DESCRIPTION
## Related Issue

#2712

## Description

Call props.onRowAddCancelled when cancelling new row editing via the add button in the header

## Related PRs

None

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* add button in the header

## Additional Notes

None